### PR TITLE
Add static site and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - name: Build site
+        run: |
+          mkdir _site
+          cp -r site/* _site/
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: _site
+      - uses: actions/deploy-pages@v2
+        with:
+          wait-for-deployment: true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # dbs_ktr
-Database and KTR-related project
+
+Database and KTR-related project.
+
+## Static site
+
+A simple static site lives in the `site/` directory. It contains plain HTML, CSS and JavaScript files.
+
+### Building locally
+
+To preview the site locally, serve the `site/` directory with any static file server. For example using Python:
+
+```bash
+python3 -m http.server --directory site 8000
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser.
+
+### Deployment
+
+A GitHub Actions workflow located at `.github/workflows/deploy.yml` builds the contents of `site/` and deploys them to GitHub Pages whenever changes are pushed to the `main` branch.
+
+Once the workflow completes, the site will be available at:
+
+```
+https://<your-github-username>.github.io/dbs_ktr/
+```
+
+Replace `<your-github-username>` with your GitHub account name.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dbs_ktr Site</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Welcome to dbs_ktr</h1>
+  <p>This is a simple static site for the dbs_ktr project.</p>
+  <button id="helloButton">Click me</button>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/site/script.js
+++ b/site/script.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const button = document.getElementById('helloButton');
+  button.addEventListener('click', function() {
+    alert('Hello from dbs_ktr!');
+  });
+});

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,12 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+  background-color: #f4f4f4;
+}
+h1 {
+  color: #333;
+}
+button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- add simple HTML/CSS/JS site in `site/`
- configure GitHub Actions workflow to deploy the site to GitHub Pages
- update README with instructions on building and deployment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a7e508fd8832483e8a4808719b00f